### PR TITLE
Remove extraneous slash from header partial

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 		<nav class="nav">
 			<div class="nav-container">
-				<a href="{{ .Site.BaseURL }}/">
+				<a href="{{ .Site.BaseURL }}">
 					<h2 class="nav-title">{{ .Site.Title }}</h2>
 				</a>
 				{{ partial "header-menu.html" . }}


### PR DESCRIPTION
When using a baseURL such as "/" (rather than hardcoding a domain), the extra slash in this partial leads to an invalid href of "//". I don't see any reason why the trailing forward slash would be needed, but would be happy to learn something new if I'm wrong. Anyways, hope this helps someone, and thanks for your hard work.