### PR TITLE
Add integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - go get github.com/gohugoio/hugo
   - git clone https://github.com/gohugoio/hugoBasicExample.git
   - cd hugoBasicExample
-  - git submodule add https://github.com/EmielH/tale-hugo.git themes/tale -f
+  - git submodule add -f https://github.com/EmielH/tale-hugo.git themes/tale
 
 script:
   - hugo -t tale

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ install:
 script:
   - hugo -t tale
   - tree
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - master
+
+install:
+  - go get github.com/gohugoio/hugo
+  - git clone https://github.com/gohugoio/hugoBasicExample.git
+  - cd hugoBasicExample
+  - git submodule add https://github.com/EmielH/tale-hugo.git themes/tale
+
+script:
+  - hugo -t tale

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 
 install:
   - go get github.com/gohugoio/hugo
+  - hugo version
   - git clone https://github.com/gohugoio/hugoBasicExample.git
   - cd hugoBasicExample
   - git submodule add -f https://github.com/EmielH/tale-hugo.git themes/tale

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - go get github.com/gohugoio/hugo
   - git clone https://github.com/gohugoio/hugoBasicExample.git
   - cd hugoBasicExample
-  - git submodule add https://github.com/EmielH/tale-hugo.git themes/tale
+  - git submodule add https://github.com/EmielH/tale-hugo.git themes/tale -f
 
 script:
   - hugo -t tale

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
 script:
   - hugo -t tale
   - tree
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
-language: go
-
-go:
-  - master
-
 install:
-  - go get github.com/gohugoio/hugo
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.51/hugo_0.51_Linux-64bit.tar.gz
+  - tar -xzvf hugo_0.51_Linux-64bit.tar.gz
+  - chmod +x hugo
+  - export PATH=$PATH:$PWD
   - hugo version
   - git clone https://github.com/gohugoio/hugoBasicExample.git
   - cd hugoBasicExample
   - git submodule add -f https://github.com/EmielH/tale-hugo.git themes/tale
+  - sudo apt-get install -y tree
+  - tree
 
 script:
   - hugo -t tale
+  - tree

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tale
 
+[![Build Status](https://travis-ci.com/EmielH/tale-hugo.svg?branch=master)](https://travis-ci.com/EmielH/tale-hugo)
+
 This is a port of the [Tale theme for Jekyll](https://github.com/chesterhow/tale) to Hugo. Tale is a minimal Jekyll theme curated for storytellers. Checkout the demo [here](https://chesterhow.github.io/tale/). I did not design this theme; I only ported it from Jekyll to Hugo.
 
 ![Tale screenshot](https://raw.githubusercontent.com/EmielH/tale-hugo/master/images/screenshot.png)


### PR DESCRIPTION
Add integration with Travis CI to make sure the theme does not break when using Hugo Basic. This might happen because of the usage of Hugo Pipes for SCSS conversion.