### PR TITLE
v0.55 .URL deprecated,and .RSSlink deprecated

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,10 +9,10 @@
 	
 	<div class="pagination">
 		{{ if .Paginator.HasPrev }}
-			<a href="{{ .Paginator.Prev.URL }}" class="left arrow">&#8592;</a>
+			<a href="{{ .Paginator.Prev.RelPermalink }}" class="left arrow">&#8592;</a>
 		{{ end }}
 		{{ if .Paginator.HasNext }}
-			<a href="{{ .Paginator.Next.URL }}" class="right arrow">&#8594;</a>
+			<a href="{{ .Paginator.Next.RelPermalink }}" class="right arrow">&#8594;</a>
 		{{ end }}
 	
 		<span>{{ .Paginator.PageNumber }}</span>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,10 +14,10 @@
 
 	<div class="pagination">
 		{{- if .PrevPage }}
-		<a href="{{ .PrevPage.URL }}" class="left arrow">&#8592;</a>
+		<a href="{{ .PrevPage.RelPermalink }}" class="left arrow">&#8592;</a>
 		{{- end }}
 		{{- if .NextPage }}
-		<a href="{{ .NextPage.URL }}" class="right arrow">&#8594;</a>
+		<a href="{{ .NextPage.RelPermalink }}" class="right arrow">&#8594;</a>
 		{{- end }}
 
 		<a href="#" class="top">Top</a>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -10,10 +10,10 @@
 	
 	<div class="pagination">
 		{{ if .Paginator.HasPrev }}
-			<a href="{{ .Paginator.Prev.URL }}" class="left arrow">&#8592;</a>
+			<a href="{{ .Paginator.Prev.RelPermalink }}" class="left arrow">&#8592;</a>
 		{{ end }}
 		{{ if .Paginator.HasNext }}
-			<a href="{{ .Paginator.Next.URL }}" class="right arrow">&#8594;</a>
+			<a href="{{ .Paginator.Next.RelPermalink }}" class="right arrow">&#8594;</a>
 		{{ end }}
 	
 		<span>{{ .Paginator.PageNumber }}</span>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -11,10 +11,10 @@
 	
 	<div class="pagination">
 		{{- if .Paginator.HasPrev -}}
-			<a href="{{ .Paginator.Prev.URL }}" class="left arrow">&#8592;</a>
+			<a href="{{ .Paginator.Prev.RelPermalink }}" class="left arrow">&#8592;</a>
 		{{- end -}}
 		{{- if .Paginator.HasNext -}}
-			<a href="{{ .Paginator.Next.URL }}" class="right arrow">&#8594;</a>
+			<a href="{{ .Paginator.Next.RelPermalink }}" class="right arrow">&#8594;</a>
 		{{- end -}}
 	
 		<span>{{ .Paginator.PageNumber }}</span>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,10 +11,10 @@
 	
 	<div class="pagination">
 		{{ if .Paginator.HasPrev }}
-			<a href="{{ .Paginator.Prev.URL }}" class="left arrow">&#8592;</a>
+			<a href="{{ .Paginator.Prev.RelPermalink }}" class="left arrow">&#8592;</a>
 		{{ end }}
 		{{ if .Paginator.HasNext }}
-			<a href="{{ .Paginator.Next.URL }}" class="right arrow">&#8594;</a>
+			<a href="{{ .Paginator.Next.RelPermalink }}" class="right arrow">&#8594;</a>
 		{{ end }}
 	
 		<span>{{ .Paginator.PageNumber }}</span>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,14 +1,14 @@
 <head>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		{{- if eq .URL "/" }}
+		{{- if eq .Permalink "/" }}
 			<meta name="description" content="{{ .Site.Params.Description }}">
 		{{- else if .Description }}
 			<meta name="description" content="{{ .Description }}">
 		{{- end }}
 	
 		<title>
-			{{- if eq .URL "/" }}
+			{{- if eq .Permalink "/" }}
 				{{ .Site.Title }}
 			{{- else }}
 				{{ .Title }} &middot; {{ .Site.Title }}
@@ -32,6 +32,6 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="{{ "images/apple-touch-icon.png" | relURL }}">
 	
 		<!-- RSS -->
-		<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+		<link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 	</head>
 	


### PR DESCRIPTION
starting with hugo v.055 

`WARN Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.`

`WARN Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: {{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}.`