### PR TITLE
delete space in title tag

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,13 +7,7 @@
 			<meta name="description" content="{{ .Description }}">
 		{{- end }}
 
-		<title>
-			{{- if .IsHome }}
-				{{ .Site.Title }}
-			{{- else }}
-				{{ .Title }} &middot; {{ .Site.Title }}
-			{{- end }}
-		</title>
+		<title>{{- if .IsHome }}{{ .Site.Title }}{{- else }}{{ .Title }} &middot; {{ .Site.Title }}{{- end }}</title>
 
 		<!-- CSS -->
 		{{- $inServerMode	:= .Site.IsServer }}


### PR DESCRIPTION
I found a strange space in a title tag when I was using this theme.
if I seted Title = "title" in confg.toml, I found issue like a below image.
So, I fixed this issue in this PR.

<img width="385"  src="https://user-images.githubusercontent.com/26073633/62218981-73e9d680-b3e8-11e9-908e-b010e63bb72d.png">
