### PR TITLE
add disqus-integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Feel free to submit pull requests for other translations of Tale's texts.
 
 [Hugo documentation for multilingual sites](//gohugo.io/content-management/multilingual/)
 
+### Disqus
+Tale supports Disqus integration, a comment system that empowers dynamic features to static websites. To install it, just add the key `disqusShortname` in your `config.toml`
+``` toml
+disqusShortname = "disqus-example"
+``` 
+Add the parameter `comments` in the front-matter of the pages where you want to allow comments 
+``` 
+---
+comments: true
+---
+```
+
 ### Custom summaries
 
 Tale allows for writing the summary of your posts manually by setting the `summary` variable in the page frontmatter. If this variable is not set, the summary that Hugo automatically generates will be used.

--- a/assets/scss/tale.scss
+++ b/assets/scss/tale.scss
@@ -6,3 +6,4 @@
 @import 'tale/layout';
 @import 'tale/pagination';
 @import 'tale/catalogue';
+@import 'tale/disqus';

--- a/assets/scss/tale/_disqus.scss
+++ b/assets/scss/tale/_disqus.scss
@@ -1,0 +1,3 @@
+.article-discussion {
+    margin: 0;
+}

--- a/layouts/disqus.html
+++ b/layouts/disqus.html
@@ -1,0 +1,22 @@
+<div id="disqus_thread"></div>
+<script>
+
+/**
+*  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+*  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
+/*
+var disqus_config = function () {
+this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
+this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+};
+*/
+(function() { // DON'T EDIT BELOW THIS LINE
+var d = document, s = d.createElement('script');
+var disqus_shortname = '{{ .Site.DisqusShortname }}';
+s.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
+s.setAttribute('data-timestamp', +new Date());
+(d.head || d.body).appendChild(s);
+})();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,9 @@
 		<footer>
+			{{ if and .Params.comments (gt (len .Site.DisqusShortname) 0) }}
+            <figure class="article-discussion">
+              {{ template "_internal/disqus.html" . }}
+            </figure>
+			{{ end }}
 			<span>
 			&copy; <time datetime="{{ now }}">{{ now.Format "2006" }}</time> {{ .Site.Author.name }}. {{ i18n "generator" | safeHTML }}
 			</span>


### PR DESCRIPTION
Following https://github.com/EmielH/tale-hugo/issues/38 I add disqus integration with simple user's configuration

User's config: add `disqusShortname` in `config.toml`
```
disqusShortname = "disqus-example"
```
And enable comments by adding the parameter in the post

```
comments: true
```


Example: https://quarrelsome-wealth.surge.sh/posts/hugo-disqus
