### PR TITLE
Add support for Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ comments: true
 ---
 ```
 
+### Google Analytics
+
+Tale supports Google Analytics integration using Hugo's provided `google_analytics_async` template.
+
+To enable it, add the `googleAnalytics` tag to your `config.toml`. It will be added on all pages.
+
+```toml
+googleAnalytics = "UA-133700000-0"
+```
+
 ### Custom summaries
 
 Tale allows for writing the summary of your posts manually by setting the `summary` variable in the page frontmatter. If this variable is not set, the summary that Hugo automatically generates will be used.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,6 @@
 <head>
+		<!-- Google Analytics -->
+		{{ template "_internal/google_analytics_async.html" . }}
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		{{- if .IsHome }}


### PR DESCRIPTION
This PR introduces Google Analytics to tale using Hugo's provided async [https://gohugo.io/templates/internal#google-analytics](internal template). Google Analytics is added to the top of the `head` tag as suggested by [https://developers.google.com/analytics/devguides/collection/analyticsjs](Google).

If the `googleAnalytics` key is added to the `config.toml`, the template renders the code for Google Analytics, otherwise it will be left out.

This resolves issue #48.