### PR TITLE
Fix favicon.ico links.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,7 +23,7 @@
 		{{ end -}}
 
 		<!-- Favicon -->
-		<link rel="icon" href="favicon.ico" />
+		<link rel="icon" href="{{ "favicon.ico" | relURL }}"/>
 		<link rel="icon" type="image/png" sizes="32x32" href="{{ "images/favicon-32x32.png" | relURL }}">
 		<link rel="icon" type="image/png" sizes="16x16" href="{{ "images/favicon-16x16.png" | relURL }}">
 		<link rel="apple-touch-icon" sizes="180x180" href="{{ "images/apple-touch-icon.png" | relURL }}">


### PR DESCRIPTION
Unlike the other links to various versions of the favicon, this one was not passed through
relURL.