### PR TITLE
Add support for OpenGraph metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ To enable it, add the `googleAnalytics` tag to your `config.toml`. It will be ad
 googleAnalytics = "UA-133700000-0"
 ```
 
+### OpenGraph
+
+Tale integrates Hugo's embedded OpenGraph template, enabling rich social previews for your page when it's shared as a link. To see how to configure it, consult the [Hugo OpenGraph template documentation](https://gohugo.io/templates/embedded/#configure-open-graph).
+
 ### Custom summaries
 
 Tale allows for writing the summary of your posts manually by setting the `summary` variable in the page frontmatter. If this variable is not set, the summary that Hugo automatically generates will be used.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,9 @@
 <head>
 		<!-- Google Analytics -->
 		{{ template "_internal/google_analytics_async.html" . }}
+		<!--- OpenGraph metadata -->
+		{{ template "_internal/opengraph.html" . }}
+	
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		{{- if .IsHome }}


### PR DESCRIPTION
Hi! This PR adds support for including OpenGraph metadata using Hugo's built-in template. I don't have much knowledge about neither this theme nor Hugo itself, but I decided I'd try to set this up as a PR instead of merely opening an issue about it. Let me know if there's something more that needs to be done for this to work properly, or if it's not within the scope of the Tale Hugo theme.