### PR TITLE
Fix internal google analytics template not found

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <head>
 		<!-- Google Analytics -->
-		{{ template "_internal/google_analytics_async.html" . }}
+		{{ template "_internal/google_analytics.html" . }}
 		<!--- OpenGraph metadata -->
 		{{ template "_internal/opengraph.html" . }}
 	


### PR DESCRIPTION
```bash
$ hugo version
hugo v0.140.2-aae02ca612a02e085c08366a9c9279f4abb39d94+extended linux/amd64 BuildDate=2024-12-30T15:01:53Z VendorInfo=gohugoio
```

I tried to use this theme, but I encountered an error that is solved by [this post](https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410).
This pull request also solves #66.
