### PR TITLE
Make header link be baseurl by default

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 		<nav class="nav">
 			<div class="nav-container">
-				<a href="{{ "/" | relURL }}">
+				<a href="{{ relURL "" }}">
 					{{ if .IsPage }}
 						<h2 class="nav-title">{{ .Site.Title }}</h2>
 					{{ else }}


### PR DESCRIPTION
I have a website hosted (on Github) at a sub-directory - in my case "brett-whitehead".  So, the URL to the top page of the website is "https://matthew-brett.github.io/brett-whitehead/index.html".  However, at the moment, Tale's header seems to assume that the top page is "/" which gives my own personal website, not the "brett-whitehead" website.   I fixed it in my own layouts like this.  Is this the right fix for a sub-directory site in general?