### PR TITLE
fix: deprecated attr to access the language code

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode | default "en" }}">
+<html lang="{{ .Site.Language.Locale | default "en" }}">
     {{ partial "head.html" . }}
     <body>
         {{ partial "header.html" . }}


### PR DESCRIPTION
This PR fixes the following build warning:

`WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.`